### PR TITLE
Enable dc.date.issued as a date field

### DIFF
--- a/config/rcaap-indexing-config.xml
+++ b/config/rcaap-indexing-config.xml
@@ -81,7 +81,7 @@
 
                 <!-- dates -->
                 <index-field name="CreativeWork.sdDatePublished" source-field="CreativeWork.sdDatePublished"
-                    sortable="true"/>
+                    sortable="true" type="DATE"/>
                 <!-- date.available -->
                 <index-field name="CreativeWork.datePublished" source-field="CreativeWork.datePublished"
                     sortable="true" type="DATE"/>


### PR DESCRIPTION
Just a minor change to the index config to enable dc.date.issued to be a date type field.